### PR TITLE
Expiry date as FrontFitTextView

### DIFF
--- a/creditcardguide/src/main/java/movile/com/creditcardguide/view/CreditCardView.java
+++ b/creditcardguide/src/main/java/movile/com/creditcardguide/view/CreditCardView.java
@@ -27,7 +27,7 @@ public class CreditCardView extends FrameLayout {
     private TextView textLabelOwner;
     private FontFitTextView textOwner;
     private TextView textLabelExpDate;
-    private TextView textExpDate;
+    private FontFitTextView textExpDate;
     private TextView textNumber;
     private FontFitTextView textCVV;
 
@@ -67,7 +67,7 @@ public class CreditCardView extends FrameLayout {
         frameLayoutBackCard = (FrameLayout) findViewById(R.id.frg_input_card_back);
 
         textNumber = (TextView) findViewById(R.id.txt_number_credit_card);
-        textExpDate = (TextView) findViewById(R.id.txt_expire_credit_card);
+        textExpDate = (FontFitTextView) findViewById(R.id.txt_expire_credit_card);
         textOwner = (FontFitTextView) findViewById(R.id.txt_name_credit_card);
         cardFront = (ImageView) findViewById(R.id.view_front_card_image);
         cardBack = (ImageView) findViewById(R.id.view_back_card_image);

--- a/creditcardguide/src/main/res/layout/view_front_credit_card.xml
+++ b/creditcardguide/src/main/res/layout/view_front_credit_card.xml
@@ -116,7 +116,7 @@
                     android:textSize="9sp" />
 
 
-                <TextView
+                <movile.com.creditcardguide.view.FontFitTextView
                     android:id="@+id/txt_expire_credit_card"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -128,6 +128,7 @@
                     android:clickable="false"
                     android:textColor="@color/white"
                     android:textSize="15sp"
+                    mask:maxFontSize="15sp"
                     android:shadowColor="@color/gray_hard_text"
                     android:shadowDx="1"
                     android:shadowDy="1"


### PR DESCRIPTION
When using CreditCardView in a small size, the expiry date gets truncated with a fixed size.